### PR TITLE
Actions do controller abrangem requisições 'jsonp'

### DIFF
--- a/app/controllers/lectures_controller.rb
+++ b/app/controllers/lectures_controller.rb
@@ -6,6 +6,9 @@ class LecturesController < ApplicationController
                                               params[:date_end])
     @participation.extend(LectureParticipationRepresenter)
 
-    respond_with(@participation)
+    respond_to do |format|
+      format.json { render :json => @participation,
+                    :callback => params[:callback] }
+    end
   end
 end

--- a/app/controllers/subjects_controller.rb
+++ b/app/controllers/subjects_controller.rb
@@ -4,13 +4,19 @@ class SubjectsController < ApplicationController
     @activity = SubjectParticipation.new(params[:subject_id])
     @activity.extend(SubjectParticipationRepresenter)
 
-    respond_with(@activity)
+    respond_to do |format|
+      format.json { render :json => @activity,
+                    :callback => params[:callback] }
+    end
   end
 
   def activities_d3
     @d3 = SubjectParticipation.new(params[:subject_id])
     @d3.extend(SubjectParticipationD3Representer)
 
-    respond_with([@d3])
+    respond_to do |format|
+      format.json { render :json => [@d3],
+                    :callback => params[:callback] }
+    end
   end
 end

--- a/spec/controllers/lectures_controller_spec.rb
+++ b/spec/controllers/lectures_controller_spec.rb
@@ -39,6 +39,15 @@ describe LecturesController do
         response.status.should eq(200)
       end
 
+      it "should return params callback" do
+        callback = "myFunct"
+        @params.store(:callback, callback)
+
+        get :participation, @params
+
+        response.body.should include "#{callback}("
+      end
+
       context "should return params correctly" do
         before do
           get :participation, @params

--- a/spec/controllers/subjects_controller_spec.rb
+++ b/spec/controllers/subjects_controller_spec.rb
@@ -36,6 +36,15 @@ describe SubjectsController do
         response.status.should eq(200)
       end
 
+      it "should return params callback" do
+        callback = "myFunct"
+        @params.store(:callback, callback)
+
+        get :activities, @params
+
+        response.body.should include "#{callback}("
+      end
+
       context "should return params correctly" do
         before do
           get :activities, @params
@@ -108,6 +117,15 @@ describe SubjectsController do
         get :activities_d3, @params
 
         response.status.should eq(200)
+      end
+
+      it "should return params callback" do
+        callback = "myFunct"
+        @params.store(:callback, callback)
+
+        get :activities, @params
+
+        response.body.should include "#{callback}("
       end
 
       context "should return params correctly" do


### PR DESCRIPTION
Alterando controladores para que as requisições feitas com dataTpe = 'jsonp' sejam recebidas corretamente no client-side.
